### PR TITLE
Use psysh@dev

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -3,6 +3,6 @@ FROM php:7.4-alpine
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 ADD http://psysh.org/manual/en/php_manual.sqlite /usr/local/share/psysh/
 RUN chmod 0755 /usr/local/bin/composer && \
-    composer g require psy/psysh:@stable
+    composer g require psy/psysh:@dev
 
 ENTRYPOINT ["/root/.composer/vendor/bin/psysh"]

--- a/7.4/goss.yaml
+++ b/7.4/goss.yaml
@@ -1,6 +1,11 @@
 process:
   php:
     running: true
+command:
+  "/root/.composer/vendor/bin/psysh --version":
+    exit-status: 0
+    stdout:
+      - /Psy Shell v\d+\.9.\d+ \(PHP 7.4.\d+ — cli\)/
 file:
   /usr/local/bin/composer:
     exists: true


### PR DESCRIPTION
Because:
- PsySH has a few updates for PHP 7.4 that aren't in stable yet